### PR TITLE
Use GNU install directory variables to determine where to install files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,8 +166,18 @@ if (NOT ${skip_unittests})
     add_subdirectory(tests)
 endif()
 
+# Set CMAKE_INSTALL_LIBDIR if not defined
+include(GNUInstallDirs)
+
+# Overridable install variables
+if (CMAKE_INSTALL_LIBDIR)
+    set (LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Library object file directory")
+else ()
+    set (LIB_INSTALL_DIR "lib" CACHE PATH "Library object file directory")
+endif ()
+
 if(WIN32)  
 else()  
-    install (TARGETS umqtt DESTINATION lib)  
-    install (FILES ${source_h_files} DESTINATION include/azureiot/azure_umqtt_c)  
+    install (TARGETS umqtt DESTINATION ${LIB_INSTALL_DIR})  
+    install (FILES ${source_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot/azure_umqtt_c)  
 endif (WIN32)  


### PR DESCRIPTION
Rather than hard-coding install directories use GNU install directory variables which can be overridden for multiarch platforms for example. 
