### PR TITLE
Set xioHandle to null when disconnecting

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -85,7 +85,6 @@ static void close_connection(MQTT_CLIENT* mqtt_client)
                 ThreadAPI_Sleep(2);
             } while (mqtt_client->clientConnected && counter < MAX_CLOSE_RETRIES);
         }
-        mqtt_client->xioHandle = NULL;
     }
     else
     {
@@ -94,6 +93,8 @@ static void close_connection(MQTT_CLIENT* mqtt_client)
             mqtt_client->disconnect_cb(mqtt_client->disconnect_ctx);
         }
     }
+
+    mqtt_client->xioHandle = NULL;
 }
 
 static void set_error_callback(MQTT_CLIENT* mqtt_client, MQTT_CLIENT_EVENT_ERROR error_type)

--- a/tests/mqtt_client_ut/mqtt_client_ut.c
+++ b/tests/mqtt_client_ut/mqtt_client_ut.c
@@ -1965,7 +1965,9 @@ TEST_FUNCTION(mqtt_client_dowork_does_nothing_if_disconnected_2)
     (void)mqtt_client_connect(mqttHandle, TEST_IO_HANDLE, &mqttOptions);
     umock_c_reset_all_calls();
 
-    STRICT_EXPECTED_CALL(xio_dowork(IGNORED_PTR_ARG));
+    //
+    // If client is disconnected, mqtt_client_dowork shall do nothing, this is why there are no expected calls here.
+    //
 
     // act
     int result = mqtt_client_disconnect(mqttHandle, NULL, NULL);


### PR DESCRIPTION
Little fix for commit 304f3817b28b9e73d8563789e55ca5c85a20dd1e
xioHandle should be set to null, even if socketConnected is false and after that when user calls `mqtt_client_dowork` function `xio_dowork` shouldn't be called. Requirement MQTT_CLIENT_18_00 says "If the client is disconnected, mqtt_client_dowork shall do nothing"