### PR TITLE
Add API to clear xio reference

### DIFF
--- a/inc/azure_umqtt_c/mqtt_client.h
+++ b/inc/azure_umqtt_c/mqtt_client.h
@@ -48,6 +48,7 @@ typedef void(*ON_MQTT_ERROR_CALLBACK)(MQTT_CLIENT_HANDLE handle, MQTT_CLIENT_EVE
 typedef void(*ON_MQTT_MESSAGE_RECV_CALLBACK)(MQTT_MESSAGE_HANDLE msgHandle, void* callbackCtx);
 typedef void(*ON_MQTT_DISCONNECTED_CALLBACK)(void* callbackCtx);
 
+MOCKABLE_FUNCTION(, void, mqtt_client_close_xio, MQTT_CLIENT_HANDLE, mqtt_client);
 MOCKABLE_FUNCTION(, MQTT_CLIENT_HANDLE, mqtt_client_init, ON_MQTT_MESSAGE_RECV_CALLBACK, msgRecv, ON_MQTT_OPERATION_CALLBACK, opCallback, void*, opCallbackCtx, ON_MQTT_ERROR_CALLBACK, onErrorCallBack, void*, errorCBCtx);
 MOCKABLE_FUNCTION(, void, mqtt_client_deinit, MQTT_CLIENT_HANDLE, handle);
 

--- a/inc/azure_umqtt_c/mqtt_client.h
+++ b/inc/azure_umqtt_c/mqtt_client.h
@@ -48,7 +48,7 @@ typedef void(*ON_MQTT_ERROR_CALLBACK)(MQTT_CLIENT_HANDLE handle, MQTT_CLIENT_EVE
 typedef void(*ON_MQTT_MESSAGE_RECV_CALLBACK)(MQTT_MESSAGE_HANDLE msgHandle, void* callbackCtx);
 typedef void(*ON_MQTT_DISCONNECTED_CALLBACK)(void* callbackCtx);
 
-MOCKABLE_FUNCTION(, void, mqtt_client_clear_xio, MQTT_CLIENT_HANDLE, mqtt_client);
+MOCKABLE_FUNCTION(, void, mqtt_client_clear_xio, MQTT_CLIENT_HANDLE, handle);
 MOCKABLE_FUNCTION(, MQTT_CLIENT_HANDLE, mqtt_client_init, ON_MQTT_MESSAGE_RECV_CALLBACK, msgRecv, ON_MQTT_OPERATION_CALLBACK, opCallback, void*, opCallbackCtx, ON_MQTT_ERROR_CALLBACK, onErrorCallBack, void*, errorCBCtx);
 MOCKABLE_FUNCTION(, void, mqtt_client_deinit, MQTT_CLIENT_HANDLE, handle);
 

--- a/inc/azure_umqtt_c/mqtt_client.h
+++ b/inc/azure_umqtt_c/mqtt_client.h
@@ -48,7 +48,7 @@ typedef void(*ON_MQTT_ERROR_CALLBACK)(MQTT_CLIENT_HANDLE handle, MQTT_CLIENT_EVE
 typedef void(*ON_MQTT_MESSAGE_RECV_CALLBACK)(MQTT_MESSAGE_HANDLE msgHandle, void* callbackCtx);
 typedef void(*ON_MQTT_DISCONNECTED_CALLBACK)(void* callbackCtx);
 
-MOCKABLE_FUNCTION(, void, mqtt_client_close_xio, MQTT_CLIENT_HANDLE, mqtt_client);
+MOCKABLE_FUNCTION(, void, mqtt_client_clear_xio, MQTT_CLIENT_HANDLE, mqtt_client);
 MOCKABLE_FUNCTION(, MQTT_CLIENT_HANDLE, mqtt_client_init, ON_MQTT_MESSAGE_RECV_CALLBACK, msgRecv, ON_MQTT_OPERATION_CALLBACK, opCallback, void*, opCallbackCtx, ON_MQTT_ERROR_CALLBACK, onErrorCallBack, void*, errorCBCtx);
 MOCKABLE_FUNCTION(, void, mqtt_client_deinit, MQTT_CLIENT_HANDLE, handle);
 

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -945,10 +945,9 @@ static void recvCompleteCallback(void* context, CONTROL_PACKET_TYPE packet, int 
     }
 }
 
-void mqtt_client_close_xio(MQTT_CLIENT_HANDLE handle)
+void mqtt_client_clear_xio(MQTT_CLIENT_HANDLE handle)
 {
   MQTT_CLIENT* mqtt_client = (MQTT_CLIENT*)handle;
-  (void)xio_close(mqtt_client->xioHandle, on_connection_closed, mqtt_client);
   // Clear the handle because we don't use it anymore
   mqtt_client->xioHandle = NULL;
 }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -945,6 +945,14 @@ static void recvCompleteCallback(void* context, CONTROL_PACKET_TYPE packet, int 
     }
 }
 
+void mqtt_client_close_xio(MQTT_CLIENT_HANDLE handle)
+{
+  MQTT_CLIENT* mqtt_client = (MQTT_CLIENT*)handle;
+  (void)xio_close(mqtt_client->xioHandle, on_connection_closed, mqtt_client);
+  // Clear the handle because we don't use it anymore
+  mqtt_client->xioHandle = NULL;
+}
+
 MQTT_CLIENT_HANDLE mqtt_client_init(ON_MQTT_MESSAGE_RECV_CALLBACK msgRecv, ON_MQTT_OPERATION_CALLBACK operation_cb, void* opCallbackCtx, ON_MQTT_ERROR_CALLBACK onErrorCallBack, void* errorCBCtx)
 {
     MQTT_CLIENT* result;

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -947,9 +947,18 @@ static void recvCompleteCallback(void* context, CONTROL_PACKET_TYPE packet, int 
 
 void mqtt_client_clear_xio(MQTT_CLIENT_HANDLE handle)
 {
-  MQTT_CLIENT* mqtt_client = (MQTT_CLIENT*)handle;
-  // Clear the handle because we don't use it anymore
-  mqtt_client->xioHandle = NULL;
+    if (handle != NULL)
+    {
+        MQTT_CLIENT *mqtt_client = (MQTT_CLIENT *)handle;
+
+        // The upstream transport handle allocates and deallocates the xio handle.
+        // The reference to that xio handle is shared between this layer (mqtt layer)
+        // and the upstream layer. The clearing done here is to signal to this layer
+        // that the handle is no longer available to be used. This is different from
+        // deiniting the mqtt client in that we do not want an entire teardown, but
+        // only a possible re-upping of the xio in the future.
+        mqtt_client->xioHandle = NULL;
+    }
 }
 
 MQTT_CLIENT_HANDLE mqtt_client_init(ON_MQTT_MESSAGE_RECV_CALLBACK msgRecv, ON_MQTT_OPERATION_CALLBACK operation_cb, void* opCallbackCtx, ON_MQTT_ERROR_CALLBACK onErrorCallBack, void* errorCBCtx)

--- a/tests/mqtt_client_ut/mqtt_client_ut.c
+++ b/tests/mqtt_client_ut/mqtt_client_ut.c
@@ -835,6 +835,50 @@ TEST_FUNCTION(mqtt_client_clear_xio_succeeds)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
+TEST_FUNCTION(mqtt_client_clear_xio_after_connect_and_do_work_succeeds)
+{
+    // arrange
+    MQTT_CLIENT_HANDLE mqttHandle = mqtt_client_init(TestRecvCallback, TestOpCallback, NULL, TestErrorCallback, NULL);
+
+    MQTT_CLIENT_OPTIONS mqttOptions = { 0 };
+    SetupMqttLibOptions(&mqttOptions, TEST_CLIENT_ID, TEST_WILL_MSG, TEST_WILL_TOPIC, TEST_USERNAME, TEST_PASSWORD, TEST_KEEP_ALIVE_INTERVAL, false, true, DELIVER_AT_MOST_ONCE);
+
+    unsigned char CONNACK_RESP[] = { 0x1, 0x0 };
+    size_t length = sizeof(CONNACK_RESP) / sizeof(CONNACK_RESP[0]);
+    BUFFER_HANDLE connack_handle = TEST_BUFFER_HANDLE;
+    STRICT_EXPECTED_CALL(BUFFER_u_char(TEST_BUFFER_HANDLE)).SetReturn(CONNACK_RESP);
+    STRICT_EXPECTED_CALL(BUFFER_length(TEST_BUFFER_HANDLE)).SetReturn(length);
+
+    (void)mqtt_client_connect(mqttHandle, TEST_IO_HANDLE, &mqttOptions);
+    g_openComplete(g_onCompleteCtx, IO_OPEN_OK);
+    g_packetComplete(mqttHandle, CONNACK_TYPE, 0, connack_handle);
+    umock_c_reset_all_calls();
+
+    g_current_ms = TEST_KEEP_ALIVE_INTERVAL * 2 * 1000;
+
+    EXPECTED_CALL(xio_dowork(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(tickcounter_get_current_ms(TEST_COUNTER_HANDLE, IGNORED_PTR_ARG)).IgnoreArgument(2);
+    STRICT_EXPECTED_CALL(mqtt_codec_ping());
+    STRICT_EXPECTED_CALL(BUFFER_length(TEST_BUFFER_HANDLE));
+    STRICT_EXPECTED_CALL(BUFFER_u_char(TEST_BUFFER_HANDLE));
+    STRICT_EXPECTED_CALL(tickcounter_get_current_ms(TEST_COUNTER_HANDLE, IGNORED_PTR_ARG)).IgnoreArgument(2);
+    EXPECTED_CALL(xio_send(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(BUFFER_delete(TEST_BUFFER_HANDLE));
+    STRICT_EXPECTED_CALL(tickcounter_get_current_ms(TEST_COUNTER_HANDLE, IGNORED_PTR_ARG)).IgnoreArgument(2);
+
+    // act
+    mqtt_client_dowork(mqttHandle);
+    mqtt_client_clear_xio(mqttHandle);
+    //This should be a NOP and therefore all above expected calls are for the first _dowork()
+    mqtt_client_dowork(mqttHandle);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    mqtt_client_deinit(mqttHandle);
+}
+
 /*Tests_SRS_MQTT_CLIENT_07_006: [If any of the parameters handle, ioHandle, or mqttOptions are NULL then mqtt_client_connect shall return a non-zero value.]*/
 TEST_FUNCTION(mqtt_client_connect_MQTT_CLIENT_HANDLE_NULL_fails)
 {

--- a/tests/mqtt_client_ut/mqtt_client_ut.c
+++ b/tests/mqtt_client_ut/mqtt_client_ut.c
@@ -809,17 +809,17 @@ TEST_FUNCTION(mqtt_client_deinit_succeeds)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(mqtt_client_close_xio_handle_NULL_succeeds)
+TEST_FUNCTION(mqtt_client_clear_xio_handle_NULL_succeeds)
 {
     // arrange
 
     // act
-    mqtt_client_close_xio(NULL);
+    mqtt_client_clear_xio(NULL);
 
     // assert
 }
 
-TEST_FUNCTION(mqtt_client_deinit_succeeds)
+TEST_FUNCTION(mqtt_client_clear_xio_succeeds)
 {
     // arrange
     MQTT_CLIENT_OPTIONS mqttOptions = { 0 };
@@ -828,12 +828,8 @@ TEST_FUNCTION(mqtt_client_deinit_succeeds)
 
     umock_c_reset_all_calls();
 
-    STRICT_EXPECTED_CALL(tickcounter_destroy(TEST_COUNTER_HANDLE));
-    EXPECTED_CALL(mqtt_codec_destroy(IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(gballoc_free(mqttHandle));
-
     // act
-    mqtt_client_close_xio(mqttHandle);
+    mqtt_client_clear_xio(mqttHandle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());

--- a/tests/mqtt_client_ut/mqtt_client_ut.c
+++ b/tests/mqtt_client_ut/mqtt_client_ut.c
@@ -809,6 +809,36 @@ TEST_FUNCTION(mqtt_client_deinit_succeeds)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
+TEST_FUNCTION(mqtt_client_close_xio_handle_NULL_succeeds)
+{
+    // arrange
+
+    // act
+    mqtt_client_close_xio(NULL);
+
+    // assert
+}
+
+TEST_FUNCTION(mqtt_client_deinit_succeeds)
+{
+    // arrange
+    MQTT_CLIENT_OPTIONS mqttOptions = { 0 };
+    SetupMqttLibOptions(&mqttOptions, TEST_CLIENT_ID, TEST_WILL_MSG, TEST_WILL_TOPIC, TEST_USERNAME, TEST_PASSWORD, TEST_KEEP_ALIVE_INTERVAL, false, true, DELIVER_AT_MOST_ONCE);
+    MQTT_CLIENT_HANDLE mqttHandle = mqtt_client_init(TestRecvCallback, TestOpCallback, NULL, TestErrorCallback, NULL);
+
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(tickcounter_destroy(TEST_COUNTER_HANDLE));
+    EXPECTED_CALL(mqtt_codec_destroy(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(mqttHandle));
+
+    // act
+    mqtt_client_close_xio(mqttHandle);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
 /*Tests_SRS_MQTT_CLIENT_07_006: [If any of the parameters handle, ioHandle, or mqttOptions are NULL then mqtt_client_connect shall return a non-zero value.]*/
 TEST_FUNCTION(mqtt_client_connect_MQTT_CLIENT_HANDLE_NULL_fails)
 {

--- a/tests/mqtt_client_ut/mqtt_client_ut.c
+++ b/tests/mqtt_client_ut/mqtt_client_ut.c
@@ -833,6 +833,9 @@ TEST_FUNCTION(mqtt_client_clear_xio_succeeds)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    mqtt_client_deinit(mqttHandle);
 }
 
 TEST_FUNCTION(mqtt_client_clear_xio_after_connect_and_do_work_succeeds)


### PR DESCRIPTION
This adds an API to clear the xio reference in the MQTT client.

Step one to fix https://github.com/Azure/azure-iot-sdk-c/issues/1666