### PR TITLE
Fix out-of-bounds write when parsing malformed Remaining Length

### DIFF
--- a/devdoc/requirement_docs/mqtt_codec_requirements.md
+++ b/devdoc/requirement_docs/mqtt_codec_requirements.md
@@ -128,3 +128,4 @@ extern int mqtt_codec_bytesReceived(MQTTCODEC_HANDLE handle, const void* buffer,
 **SRS_MQTT_CODEC_07_033: [** mqtt_codec_bytesReceived constructs a sequence of bytes into the corresponding MQTT packets and on success returns zero. **]**  
 **SRS_MQTT_CODEC_07_034: [** Upon a constructing a complete MQTT packet mqtt_codec_bytesReceived shall call the ON_PACKET_COMPLETE_CALLBACK function. **]**  
 **SRS_MQTT_CODEC_07_035: [** If any error is encountered then the packet state will be marked as error and mqtt_codec_bytesReceived shall return a non-zero value. **]**  
+**SRS_MQTT_CODEC_07_037: [** If the Remaining Length index has reached the maximum number of bytes (4) then prepareheaderDataInfo shall return a non-zero value without writing past the storeRemainLen buffer. **]**  

--- a/src/mqtt_codec.c
+++ b/src/mqtt_codec.c
@@ -516,6 +516,15 @@ static int prepareheaderDataInfo(MQTTCODEC_INSTANCE* codecData, uint8_t remainLe
 {
     int result;
     result = 0;
+    /* Codes_SRS_MQTT_CODEC_07_037: [ If the Remaining Length index has reached the maximum number of bytes (4) then prepareheaderDataInfo shall return a non-zero value without writing past the storeRemainLen buffer. ] */
+    if (codecData->remainLenIndex >= (sizeof(codecData->storeRemainLen) / sizeof(codecData->storeRemainLen[0])))
+    {
+        // The maximum number of bytes in the Remaining Length field is four.
+        // Guard against writing past storeRemainLen if the parser is re-entered
+        // after a Remaining Length error left remainLenIndex at the maximum.
+        LogError("MQTT packet len is invalid");
+        return MU_FAILURE;
+    }
     codecData->storeRemainLen[codecData->remainLenIndex++] = remainLen;
     if (remainLen <= 0x7f)
     {

--- a/tests/mqtt_codec_ut/mqtt_codec_ut.c
+++ b/tests/mqtt_codec_ut/mqtt_codec_ut.c
@@ -1523,6 +1523,40 @@ TEST_FUNCTION(mqtt_codec_bytesReceived_buffer_too_large_fail)
     mqtt_codec_destroy(handle);
 }
 
+// Tests that a malformed Remaining Length (four continuation bytes that drive
+// remainLenIndex to its maximum) followed by another segment of continuation
+// bytes does not produce a heap out-of-bounds write into storeRemainLen.
+TEST_FUNCTION(mqtt_codec_bytesReceived_malformed_remaining_length_no_oob_fail)
+{
+    // arrange
+    // Segment 1: PUBLISH type byte + four continuation Remaining-Length bytes.
+    unsigned char MALFORMED_SEG_1[] = { 0x30, 0x80, 0x80, 0x80, 0x80 };
+    // Segment 2: additional continuation bytes that, before the fix, were
+    // written one slot past the 4-byte storeRemainLen array on each iteration.
+    unsigned char MALFORMED_SEG_2[] = { 0x80, 0x80, 0x80, 0x80 };
+
+    TEST_COMPLETE_DATA_INSTANCE testData = { 0 };
+
+    MQTTCODEC_HANDLE handle = mqtt_codec_create(TestOnCompleteCallback, &testData);
+
+    umock_c_reset_all_calls();
+
+    g_curr_packet_type = PUBLISH_TYPE;
+
+    // act
+    int result_seg_1 = mqtt_codec_bytesReceived(handle, MALFORMED_SEG_1, sizeof(MALFORMED_SEG_1) / sizeof(MALFORMED_SEG_1[0]));
+    int result_seg_2 = mqtt_codec_bytesReceived(handle, MALFORMED_SEG_2, sizeof(MALFORMED_SEG_2) / sizeof(MALFORMED_SEG_2[0]));
+
+    // assert
+    ASSERT_ARE_NOT_EQUAL(int, 0, result_seg_1);
+    ASSERT_ARE_NOT_EQUAL(int, 0, result_seg_2);
+    ASSERT_IS_FALSE(g_callbackInvoked);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    mqtt_codec_destroy(handle);
+}
+
 TEST_FUNCTION(mqtt_codec_bytesReceived_after_large_buffer_succeed)
 {
     // arrange


### PR DESCRIPTION
prepareheaderDataInfo wrote the incoming Remaining Length byte into the fixed 4-byte storeRemainLen array before validating the index. A malformed Remaining Length could leave remainLenIndex at its maximum and route subsequent bytes back into the parser, writing past the buffer.

Add a bounds check at the top of prepareheaderDataInfo so it returns an error before writing once the maximum index is reached, plus a unit test and requirement covering the malformed input.